### PR TITLE
Fix missing import in code sample

### DIFF
--- a/src/guide/beginner/basic_bot.md
+++ b/src/guide/beginner/basic_bot.md
@@ -97,7 +97,7 @@ Yes! That's it! We got our own ping command. Now try running the bot and send `!
 Got stuck? This is our resulting code,
 
 ```ts
-import { Client, Intents } from './deps.ts'
+import { Client, Intents, Message } from './deps.ts'
 
 const client = new Client()
 

--- a/src/guide/slash_commands/tag_bot.md
+++ b/src/guide/slash_commands/tag_bot.md
@@ -44,7 +44,8 @@ import {
     SlashCommandPartial, 
     Interaction, 
     InteractionResponseType, 
-    SlashCommandOptionType 
+    SlashCommandOptionType,
+    Intents 
 } from "./deps.ts"
 
 class TagBot extends Client {

--- a/src/guide/slash_commands/tag_bot.md
+++ b/src/guide/slash_commands/tag_bot.md
@@ -44,8 +44,7 @@ import {
     SlashCommandPartial, 
     Interaction, 
     InteractionResponseType, 
-    SlashCommandOptionType,
-    Intents 
+    SlashCommandOptionType 
 } from "./deps.ts"
 
 class TagBot extends Client {


### PR DESCRIPTION
Hey,

Just noticed a missing import on the code samples, as well as the edit links on the footer being broken. I don't think I can fix the latter. It opens to master branch instead of main branch, but still attempts to open the markdown files rather than the hosted html.

Missing import is fixed. Loving the lib so far :)